### PR TITLE
Changed prorogation start date, changed current record

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
         }
 
         var noGov = (function () {
-            var noGovDate = new Date(2019, 7, 27);
+            var noGovDate = new Date(2019, 8, 9);
             var currentRecordDays = 589;
             var daysSinceGov = Date.daysSince(noGovDate);
 

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
 
         var noGov = (function () {
             var noGovDate = new Date(2019, 8, 9);
-            var currentRecordDays = 589;
+            var currentRecordDays = 34;
             var daysSinceGov = Date.daysSince(noGovDate);
 
             return {


### PR DESCRIPTION
Changed prorogation start date to September 9th, and changed current record to 34 days (not entirely certain of this, can't find any evidence other than [this](https://www.theguardian.com/politics/2019/aug/28/pms-plan-to-suspend-parliament-aimed-at-evading-scrutiny-of-mps) article).